### PR TITLE
Fix failing tests for Pydantic v2 compatibility

### DIFF
--- a/src/yaloader/constructor.py
+++ b/src/yaloader/constructor.py
@@ -12,6 +12,17 @@ from yaloader import VarYAMLConfigBase, YAMLBaseConfig, YAMLConfigLoader, YAMLVa
 from yaloader.representer import get_representer_for_class
 
 
+def _check_extra_fields(cls: Type[YAMLBaseConfig], mapping: dict, node: yaml.Node) -> None:
+    """Check for extra fields not defined in the model."""
+    extra_fields = set(mapping.keys()) - set(cls.model_fields.keys())
+    if extra_fields:
+        raise YAMLValueError(
+            f"Could not validate the configuration for the tag {node.tag}",
+            node.start_mark,
+            f"extra fields not permitted: {extra_fields}",
+        )
+
+
 def get_constructor_for_class(cls: Type[YAMLBaseConfig]):
     def constructor(loader: YAMLConfigLoader, node: yaml.MappingNode) -> YAMLBaseConfig:
         """Construct the config object from a mapping."""
@@ -23,6 +34,9 @@ def get_constructor_for_class(cls: Type[YAMLBaseConfig]):
             )
         # Get the mapping in a dictionary
         mapping = loader.construct_mapping(node, deep=True)
+        # Check for extra fields when config is extra="forbid"
+        if cls.model_config.get("extra") == "forbid":
+            _check_extra_fields(cls, mapping, node)
         # Construct an object of this config class WITHOUT validating the inputs
         config_instance: YAMLBaseConfig = cls.model_construct(**mapping)
         # Validate the inputs, but ignore missing errors
@@ -39,11 +53,10 @@ def get_constructor_for_class(cls: Type[YAMLBaseConfig]):
     return constructor
 
 
-def get_multi_constructor_for_vars(yaml_loader: Type[YAMLConfigLoader], yaml_dumper: Optional[Type[
-    YAMLConfigDumper]] = None):
-    def constructor(
-            loader: YAMLConfigLoader, tag_suffix: str, node: yaml.MappingNode
-    ) -> YAMLBaseConfig:
+def get_multi_constructor_for_vars(
+    yaml_loader: Type[YAMLConfigLoader], yaml_dumper: Optional[Type[YAMLConfigDumper]] = None
+):
+    def constructor(loader: YAMLConfigLoader, tag_suffix: str, node: yaml.MappingNode) -> YAMLBaseConfig:
         """Construct the config object from a mapping."""
         if not isinstance(node, yaml.MappingNode):
             raise ParserError(
@@ -96,6 +109,9 @@ def get_multi_constructor_for_vars(yaml_loader: Type[YAMLConfigLoader], yaml_dum
             var_yaml_config_class = VarYAMLConfig
             yaml_loader.yaml_config_classes[node.tag] = var_yaml_config_class
 
+        # Check for extra fields when config is extra="forbid"
+        if var_yaml_config_class.model_config.get("extra") == "forbid":
+            _check_extra_fields(var_yaml_config_class, mapping, node)
         # Construct an object of this config class WITHOUT validating the inputs
         config_instance: YAMLBaseConfig = var_yaml_config_class.model_construct(**mapping)
         # Validate the inputs, but ignore missing errors
@@ -113,10 +129,10 @@ def get_multi_constructor_for_vars(yaml_loader: Type[YAMLConfigLoader], yaml_dum
 
 
 def loads(
-        loaded_class: Optional[Type] = None,
-        overwrite_tag: bool = False,
-        yaml_loader: Optional[Type[YAMLConfigLoader]] = YAMLConfigLoader,
-        yaml_dumper: Optional[Type[YAMLConfigDumper]] = YAMLConfigDumper,
+    loaded_class: Optional[Type] = None,
+    overwrite_tag: bool = False,
+    yaml_loader: Optional[Type[YAMLConfigLoader]] = YAMLConfigLoader,
+    yaml_dumper: Optional[Type[YAMLConfigDumper]] = YAMLConfigDumper,
 ) -> Callable[[Type[YAMLBaseConfig]], Type[YAMLBaseConfig]]:
     """A class decorator for yaml configs to add a simple load function for a given class.
 
@@ -136,17 +152,17 @@ def loads(
             elif isinstance(cls._yaml_tag, str):
                 cls.set_yaml_tag(cls._yaml_tag)
             else:
-                raise TypeError(f'The _yaml_tag attribute has to be of class str or pydantic.ModelPrivateAttr '
-                                f'but got {type(cls._yaml_tag)}.')
+                raise TypeError(
+                    f"The _yaml_tag attribute has to be of class str or pydantic.ModelPrivateAttr "
+                    f"but got {type(cls._yaml_tag)}."
+                )
 
         # Set the _loaded_class attribute
         if loaded_class is not None:
             setattr(cls, "_loaded_class", loaded_class)
 
         if yaml_loader is not None:
-            yaml_loader.add_config_constructor(
-                cls, get_constructor_for_class(cls), overwrite_tag=overwrite_tag
-            )
+            yaml_loader.add_config_constructor(cls, get_constructor_for_class(cls), overwrite_tag=overwrite_tag)
         if yaml_dumper is not None:
             yaml_dumper.add_representer(cls, get_representer_for_class(cls))
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -25,13 +25,13 @@ def large_config_list(yaml_loader, config_loader):
 
         field_definitions = {f"attribute{j}": (int, int(j)) if (j + i) % 2 == 0 else (str, str(j)) for j in
                              range(min(i, 20))}
-        field_definitions["_yaml_tag"] = f'!Config{i}'
 
         config_class = pydantic.create_model(
-            __model_name=f'Config{i}Config',
+            f'Config{i}Config',
             __base__=base_config,
             **field_definitions
         )
+        config_class._yaml_tag = f'!Config{i}'
         config_class = yaloader.constructor.loads(yaml_loader=yaml_loader)(config_class)
         config_list.append(config_class)
 


### PR DESCRIPTION
## Summary
- Add explicit extra field check before `model_construct` in YAML constructors. Pydantic v2's `model_construct` silently drops unknown fields, bypassing `extra="forbid"` validation. The check only runs when the config has `extra="forbid"` set.
- Fix `pydantic.create_model` call in caching tests: use positional `model_name` argument (Pydantic v2 removed `__model_name` keyword).
- Set `_yaml_tag` after `create_model` instead of passing it as a field definition. Pydantic v2 interprets underscore-prefixed strings in `create_model` as type annotations, and `!Config0` is not valid Python syntax.

All 32 tests pass.

Closes #22