### PR TITLE
Add datetime.date and bool to deep_construct known types

### DIFF
--- a/src/yaloader/config_loader.py
+++ b/src/yaloader/config_loader.py
@@ -85,7 +85,7 @@ class ConfigLoader:
             }
         # If v is an unhandled type log a warning and return v itself
         elif v is not None and not isinstance(
-                v, (int, float, str, PosixPath, datetime.timedelta, datetime.datetime)
+                v, (bool, int, float, str, PosixPath, datetime.date, datetime.timedelta, datetime.datetime)
         ):
             logger.warning(
                 f"Got type {type(v)} while deep construct of a yaml config which is not explicitly handled."


### PR DESCRIPTION
## Summary
- Add `datetime.date` to the known safe types in `deep_construct`. PyYAML's SafeLoader parses bare dates (e.g. `2024-01-01`) as `datetime.date`, which is not a superclass of `datetime.datetime`, causing spurious warnings.
- Add `bool` explicitly rather than relying on it being a subclass of `int`.

Closes #15