### PR TITLE
Invalidate cache when new configs are added

### DIFF
--- a/src/yaloader/config_loader.py
+++ b/src/yaloader/config_loader.py
@@ -258,6 +258,15 @@ class ConfigLoader:
             for field in fields:
                 config_attributes[field] = update_dict[field]
 
+    def _clear_cache(self):
+        """Clear the construction cache.
+
+        Must be called whenever configs_per_tag is modified, since
+        cached results may depend on the old config state.
+        """
+        if self.cacheing:
+            self.cache = {}
+
     def add_config(self, config_with_priority: ConfigWithPriority):
         """Add a config object together with its priority to the loader."""
         config: YAMLBaseConfig = config_with_priority.config
@@ -266,6 +275,7 @@ class ConfigLoader:
             self.configs_per_tag[tag].append(config_with_priority)
         except KeyError:
             self.configs_per_tag[tag] = [config_with_priority]
+        self._clear_cache()
 
     def add_single_config_string(self, string: str, priority):
         """Add a yaml string with a single config object."""

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -87,3 +87,14 @@ def test_caching_load_large_config_list(config_loader, caching_config_loader, la
     config_list_cached = caching_config_loader.construct_from_string(load_string)
 
     assert config_list == config_list_cached
+
+
+def test_cache_invalidated_on_new_config(caching_config_loader, AConfig):
+    """Cache must be cleared when new configs are loaded."""
+    config_before = caching_config_loader.construct_from_string('!A {}')
+    assert config_before.attribute == 0
+
+    caching_config_loader.add_single_config_string('!A {attribute: 42}', priority=1)
+
+    config_after = caching_config_loader.construct_from_string('!A {}')
+    assert config_after.attribute == 42


### PR DESCRIPTION
## Summary
- Clear the construction cache in `add_config` so that loading new configs after a construction doesn't return stale results
- Add test verifying cache invalidation works

Closes #10