### PR TITLE
Enforce strict YAML document format in add_config_data

### DIFF
--- a/src/yaloader/config_loader.py
+++ b/src/yaloader/config_loader.py
@@ -260,23 +260,51 @@ class ConfigLoader:
         config_with_priority = ConfigWithPriority(config=config, priority=priority)
         self.add_config(config_with_priority)
 
-    def add_config_data(self, config_data: list[dict | list], priority: int | None = None) -> None:
-        """Add multiple configs or priorities."""
+    def add_config_data(self, config_data: list[dict | list | None], priority: int | None = None) -> None:
+        """Add multiple configs or priorities.
+
+        Each element in config_data corresponds to one YAML document and must be one of:
+
+        - ``None``: ignored (empty YAML document).
+        - ``dict`` with ``"priority"`` key: sets the priority (0-100) for subsequent config lists.
+        - ``dict`` with ``"anchors"`` key: ignored (anchors are resolved during YAML parsing).
+          A dict may contain both ``"priority"`` and ``"anchors"`` but no other keys.
+        - ``list`` of :class:`YAMLBaseConfig`: configs to store with the current priority.
+        """
+        _ALLOWED_DICT_KEYS = {"priority", "anchors"}
         given_priority = priority
         for config_element in config_data:
-            if isinstance(config_element, dict) and "priority" in config_element:
-                priority = config_element["priority"] if given_priority is None else given_priority
+            if config_element is None:
+                continue
+            elif isinstance(config_element, dict):
+                has_priority = "priority" in config_element
+                has_anchors = "anchors" in config_element
+                extra_keys = set(config_element.keys()) - _ALLOWED_DICT_KEYS
+                if extra_keys:
+                    raise ValueError(
+                        f"Dict documents in config data may only contain 'priority' and/or 'anchors' keys, "
+                        f"got extra keys: {extra_keys}"
+                    )
+                if not has_priority and not has_anchors:
+                    raise ValueError("Dict documents in config data must contain a 'priority' and/or 'anchors' key.")
+                if has_priority:
+                    priority = config_element["priority"] if given_priority is None else given_priority
             elif isinstance(config_element, list):
                 for config in config_element:
-                    if isinstance(config, YAMLBaseConfig):
-                        config_with_priority = ConfigWithPriority(
-                            config=config,
-                            priority=priority if priority is not None else 0,
+                    if not isinstance(config, YAMLBaseConfig):
+                        raise ValueError(
+                            f"Config lists must only contain YAMLBaseConfig instances, "
+                            f"got {type(config).__name__}: {config!r}"
                         )
-                        self.add_config(config_with_priority)
+                    config_with_priority = ConfigWithPriority(
+                        config=config,
+                        priority=priority if priority is not None else 0,
+                    )
+                    self.add_config(config_with_priority)
             else:
                 raise ValueError(
-                    "Entries in the config files must be mapping containing a priority key or a list of configs."
+                    f"Documents in config data must be a dict (with 'priority'/'anchors' key), "
+                    f"a list of configs, or None. Got {type(config_element).__name__}."
                 )
 
     def load_string(self, string: str, priority: int | None = None) -> None:

--- a/tests/test_anchors.py
+++ b/tests/test_anchors.py
@@ -15,7 +15,8 @@ def test_anchor_single_document(config_loader, AConfig):
 def test_anchor_multiple_document(config_loader, AConfig):
     config_loader.load_string(
         """
-        - attribute: &name 1
+        anchors:
+            attribute: &name 1
         """
     )
     config_list = config_loader.construct_from_string(
@@ -53,7 +54,8 @@ def test_anchors_isolated_between_config_loaders(yaml_loader, AConfig):
     loader_a = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
     loader_a.load_string(
         """
-        - attribute: &shared 42
+        anchors:
+            attribute: &shared 42
         """
     )
 
@@ -73,7 +75,8 @@ def test_anchors_do_not_leak_back_to_parent_yaml_loader(yaml_loader, AConfig):
     loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
     loader.load_string(
         """
-        - attribute: &leaked 99
+        anchors:
+            attribute: &leaked 99
         """
     )
 
@@ -87,14 +90,16 @@ def test_two_loaders_same_anchor_name_independent(yaml_loader, AConfig):
     loader_a = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
     loader_a.load_string(
         """
-        - attribute: &val 10
+        anchors:
+            attribute: &val 10
         """
     )
 
     loader_b = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
     loader_b.load_string(
         """
-        - attribute: &val 20
+        anchors:
+            attribute: &val 20
         """
     )
 
@@ -143,12 +148,14 @@ def test_anchors_persist_across_multiple_load_string_calls(yaml_loader, AConfig)
     loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
     loader.load_string(
         """
-        - attribute: &first 1
+        anchors:
+            attribute: &first 1
         """
     )
     loader.load_string(
         """
-        - attribute: &second 2
+        anchors:
+            attribute: &second 2
         """
     )
 
@@ -170,7 +177,8 @@ def test_isolation_with_pre_existing_anchors_on_parent(yaml_loader, AConfig):
     loader_first = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
     loader_first.load_string(
         """
-        - attribute: &preexisting 77
+        anchors:
+            attribute: &preexisting 77
         """
     )
 

--- a/tests/test_config_loader_edge_cases.py
+++ b/tests/test_config_loader_edge_cases.py
@@ -158,8 +158,85 @@ def test_add_config_data_invalid_entry_raises(yaml_loader):
         val: int = 0
 
     loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
-    with pytest.raises(ValueError, match="Entries in the config files must be"):
+    with pytest.raises(ValueError, match="Documents in config data must be"):
         loader.add_config_data(["not a dict or list"])
+
+
+def test_add_config_data_none_document_ignored(yaml_loader):
+    """None documents (empty YAML documents) are silently ignored."""
+
+    @yaloader.constructor.loads(yaml_loader=yaml_loader)
+    class NoneDocConfig(YAMLBaseConfig):
+        _yaml_tag = "!NoneDoc"
+        val: int = 0
+
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    loader.add_config_data([None, [NoneDocConfig(val=1)], None])
+    result = loader.construct_from_string("!NoneDoc {}")
+    assert result == NoneDocConfig(val=1)
+
+
+def test_add_config_data_anchors_document(yaml_loader):
+    """Anchor-only dict documents are accepted and don't store configs."""
+
+    @yaloader.constructor.loads(yaml_loader=yaml_loader)
+    class AnchorDocConfig(YAMLBaseConfig):
+        _yaml_tag = "!AnchorDoc"
+        val: int = 0
+
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    loader.load_string("anchors:\n  x: &x_val 42\n---\n- !AnchorDoc {val: *x_val}")
+    result = loader.construct_from_string("!AnchorDoc {}")
+    assert result == AnchorDocConfig(val=42)
+
+
+def test_add_config_data_combined_priority_anchors(yaml_loader):
+    """A dict with both 'priority' and 'anchors' keys is accepted."""
+
+    @yaloader.constructor.loads(yaml_loader=yaml_loader)
+    class ComboConfig(YAMLBaseConfig):
+        _yaml_tag = "!Combo"
+        val: int = 0
+
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    loader.load_string("priority: 10\nanchors:\n  v: &v 99\n---\n- !Combo {val: *v}")
+    result = loader.construct_from_string("!Combo {}")
+    assert result == ComboConfig(val=99)
+
+
+def test_add_config_data_dict_without_priority_or_anchors_raises(yaml_loader):
+    """A dict without 'priority' or 'anchors' key raises ValueError."""
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    with pytest.raises(ValueError, match="got extra keys"):
+        loader.add_config_data([{"something_else": 42}])
+
+
+def test_add_config_data_empty_dict_raises(yaml_loader):
+    """An empty dict raises ValueError."""
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    with pytest.raises(ValueError, match="must contain a 'priority' and/or 'anchors' key"):
+        loader.add_config_data([{}])
+
+
+def test_add_config_data_dict_with_extra_keys_raises(yaml_loader):
+    """A dict with extra keys beyond 'priority'/'anchors' raises ValueError."""
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    with pytest.raises(ValueError, match="got extra keys"):
+        loader.add_config_data([{"priority": 10, "unexpected": True}])
+
+
+def test_add_config_data_non_config_in_list_raises(yaml_loader):
+    """Non-YAMLBaseConfig items in a config list raise ValueError."""
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    with pytest.raises(ValueError, match="Config lists must only contain YAMLBaseConfig"):
+        loader.add_config_data([[{"not": "a config"}]])
+
+
+def test_add_config_data_bare_scalar_raises(yaml_loader):
+    """Bare scalars (int, str) as documents raise ValueError."""
+    loader = ConfigLoader(yaml_loader=yaml_loader, cacheing=False)
+    with pytest.raises(ValueError, match="Documents in config data must be"):
+        loader.add_config_data([42])
 
 
 def test_add_single_config_string_non_config_raises(yaml_loader):


### PR DESCRIPTION
Replaces loose input handling in `add_config_data` with three explicit document types: `priority` dict, `anchors` dict, and config list. Non-config items in config lists and unexpected dict keys now raise `ValueError` instead of being silently ignored. Anchor-only documents use the new `anchors:` key format.

Closes #29